### PR TITLE
[#2] Create the Infra to deploy Centauri Web using HCL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+**/.terraform/**

--- a/hcl/aws_ecr/.terraform.lock.hcl
+++ b/hcl/aws_ecr/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.5.0"
+  hashes = [
+    "h1:6y12cTFaxpFv4qyU3gkV9M15eSBBrgInoKY1iaHuhvg=",
+    "zh:0573de96ba316d808be9f8d6fc8e8e68e0e6b614ed4d707bd236c4f7b46ac8b1",
+    "zh:37560469042f5f43fdb961eb6e6b0a8f95057df68af2c1168d5b8c66ddcb1512",
+    "zh:44bb4f6bc1f58e19b8bf7041f981a2549a351762d17dd39654eb24d1fa7991c7",
+    "zh:53af6557b68e547ac5c02cfd0e47ef63c8e9edfacf46921ccc97d73c0cd362c9",
+    "zh:578a583f69a8e5947d66b2b9d6969690043b6887f6b574263be7ef05f82a82ad",
+    "zh:6c2d42f30db198a4e7badd7f8037ef9bd951cfd6cf40328c6a7eed96801a374e",
+    "zh:758f3fc4d833dbdda57a4db743cbbddc8fd8c0492df47771b848447ba7876ce5",
+    "zh:78241bd45e2f6102055787b3697849fee7e9c28a744ba59cad956639c1aca07b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a3a7f4699c097c7b8364d05a5df9f3bd5d005fd5736c28ec5dc8f8c0ee340512",
+    "zh:bf875483bf2ad6cfb4029813328cdcd9ea40f50b9f1c265f4e742fe8cc456157",
+    "zh:f4722596e8b5f012013f87bf4d2b7d302c248a04a144de4563b3e3f754a30c51",
+  ]
+}

--- a/hcl/aws_ecr/README.md
+++ b/hcl/aws_ecr/README.md
@@ -1,0 +1,4 @@
+## How to run
+
+1/ Update the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` on https://app.terraform.io/app/nimble/workspaces/nimble-growth-37-centauri-ecr/variables.
+2/ Terraform apply from local machine.

--- a/hcl/aws_ecr/main.tf
+++ b/hcl/aws_ecr/main.tf
@@ -1,0 +1,57 @@
+terraform {
+  cloud {
+    organization = "nimble"
+
+    workspaces {
+      name = "nimble-growth-37-centauri-ecr"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_ecr_repository" "app" {
+  name = var.name
+}
+
+resource "aws_ecr_lifecycle_policy" "foopolicy" {
+  repository = aws_ecr_repository.app.name
+
+  policy = <<EOF
+{
+    "rules": [
+        {
+            "rulePriority": 1,
+            "description": "Delete build",
+            "selection": {
+                "countType": "imageCountMoreThan",
+                "countNumber": 5,
+                "tagStatus": "tagged",
+                "tagPrefixList": [
+                    "development-sit-",
+                    "development-uat-"
+                ]
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 2,
+            "description": "Delete untagged images",
+            "selection": {
+                "countType": "sinceImagePushed",
+                "countNumber": 1,
+                "tagStatus": "untagged",
+                "countUnit": "days"
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+}
+EOF
+}

--- a/hcl/aws_ecr/variables.tf
+++ b/hcl/aws_ecr/variables.tf
@@ -1,0 +1,2 @@
+variable "name" {}
+variable "region" {}

--- a/hcl/centauri_web/.terraform.lock.hcl
+++ b/hcl/centauri_web/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.4.0"
+  hashes = [
+    "h1:e9Lg+N7g//WXWDGPPbisC1w34HFIDZrCNkJFbP+z5Rk=",
+    "zh:087e8e1b9c3d2c9d547181aa88f75fd42d9800eea6d37c0276b1208c427113ff",
+    "zh:25c3deac14f06a7da5d4d8b56dd5e25a24b5c3bb6bb7a585145d7df1a6e5bc3f",
+    "zh:5bd23fc03cd51eca3f1e4e4414624dcc4f075eca5cf5aabf06b54b4edded5c50",
+    "zh:8399507975a422a84b93b24c07db34cc9342f54aa693eace1b451c6b1ab54b87",
+    "zh:9618bed0832433fee57579d4a001479b08e2092d0c08539edb897f57f6ea0114",
+    "zh:b0b9060bc367c5fb6175c7ae59382fd6107ab0c0bad6e40cd3205127d8e6717d",
+    "zh:b160122057659cceb72f78a86483f71d59742502dad23b770dc4248b8e94edd4",
+    "zh:cb927f4622ef9bf439b867aef760c948839e1cec2ddb8bdba7abfc5183124360",
+    "zh:e37ce5054a5838eda190f286a62eeb7146087863e38b1a205aa0eb12a5e765b9",
+    "zh:e38856fd703b2f6e08a35cbe5ddab9a734c9608d2372411bfa6ef1b05ffeb758",
+    "zh:f342e638d9672d969ed3946b9f0650cf327690b35e0812b2ddae97bd32c2d946",
+  ]
+}

--- a/hcl/centauri_web/README.md
+++ b/hcl/centauri_web/README.md
@@ -1,0 +1,6 @@
+## How to run
+
+1/ Update the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` on https://app.terraform.io/app/nimble/workspaces/nimble-growth-37-centauri-hcl/variables.
+2/ Terraform apply from the local machine.
+3/ Run `terraform output alb_dns` to grab the Endpoint.
+4/ Visit the Endpoint aforementioned.

--- a/hcl/centauri_web/main.tf
+++ b/hcl/centauri_web/main.tf
@@ -54,4 +54,6 @@ module "ecs" {
   database_password = var.db_password
   database_host     = module.rds.aws_db_instance_host
   database_port     = module.rds.aws_db_instance_port
+
+  app_secret_key_base = var.app_secret_key_base
 }

--- a/hcl/centauri_web/main.tf
+++ b/hcl/centauri_web/main.tf
@@ -1,0 +1,57 @@
+terraform {
+  cloud {
+    organization = "nimble"
+
+    workspaces {
+      name = "nimble-growth-37-centauri-hcl"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+module "alb" {
+  source = "./modules/alb"
+
+  name       = var.name
+  vpc_id     = var.vpc_id
+  subnet_ids = var.subnet_ids
+}
+
+module "rds" {
+  source = "./modules/rds"
+
+  db_identifier = var.name
+  db_name       = var.db_name
+  username      = var.db_username
+  password      = var.db_password
+}
+
+module "log" {
+  source = "./modules/log"
+
+  name = var.name
+}
+
+module "ecs" {
+  source = "./modules/ecs"
+
+  image = var.docker_image
+
+  region     = var.region
+  name       = var.name
+  subnet_ids = var.subnet_ids
+
+  aws_alb_target_group_arn = module.alb.alb_target_group_arn
+  aws_alb_dns              = module.alb.alb_dns
+
+  cloudwatch_log_group_arn = module.log.cloudwatch_log_group_arn
+
+  database_name     = var.db_name
+  database_username = var.db_username
+  database_password = var.db_password
+  database_host     = module.rds.aws_db_instance_host
+  database_port     = module.rds.aws_db_instance_port
+}

--- a/hcl/centauri_web/modules/alb/main.tf
+++ b/hcl/centauri_web/modules/alb/main.tf
@@ -1,0 +1,37 @@
+resource "aws_lb" "app" {
+  name               = var.name
+  load_balancer_type = "application"
+
+  subnets = var.subnet_ids
+}
+
+resource "aws_lb_target_group" "app" {
+  name                 = var.name
+  port                 = 4000
+  protocol             = "HTTP"
+  vpc_id               = var.vpc_id
+  deregistration_delay = 100 # Given the instance 100 seconds to finish the queued requests before removing out the ALB
+  target_type          = "ip"
+
+  health_check {
+    interval            = 70
+    path                = "/"
+    port                = 4000
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 65
+    protocol            = "HTTP"
+    matcher             = "200"
+  }
+}
+
+resource "aws_lb_listener" "app_http" {
+  load_balancer_arn = aws_lb.app.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+}

--- a/hcl/centauri_web/modules/alb/outputs.tf
+++ b/hcl/centauri_web/modules/alb/outputs.tf
@@ -1,0 +1,7 @@
+output "alb_target_group_arn" {
+  value = aws_lb_target_group.app.arn
+}
+
+output "alb_dns" {
+  value = aws_lb.app.dns_name
+}

--- a/hcl/centauri_web/modules/alb/variables.tf
+++ b/hcl/centauri_web/modules/alb/variables.tf
@@ -1,0 +1,3 @@
+variable "name" {}
+variable "vpc_id" {}
+variable "subnet_ids" {}

--- a/hcl/centauri_web/modules/ecs/main.tf
+++ b/hcl/centauri_web/modules/ecs/main.tf
@@ -66,7 +66,7 @@ resource "aws_ecs_task_definition" "main" {
       },
       {
         name  = "SECRET_KEY_BASE"
-        value = "odb/2tIZ9+mBFI8rBMK/OWCRjLuDB+PfKtzv6Td73OfyjDPAjWWLdOmhRozk50rV"
+        value = var.app_secret_key_base
       },
       {
         name  = "PORT"

--- a/hcl/centauri_web/modules/ecs/main.tf
+++ b/hcl/centauri_web/modules/ecs/main.tf
@@ -1,0 +1,100 @@
+data "aws_iam_policy_document" "ecs_task_execution" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_ecs_cluster" "main" {
+  name = var.name
+}
+
+resource "aws_iam_role" "ecs_task_execution" {
+  name               = var.name
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution.json
+}
+
+resource "aws_iam_role_policy_attachment" "ecs-task-execution-role-policy-attachment" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_ecs_task_definition" "main" {
+  family                   = var.name
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 256
+  memory                   = 512
+
+  execution_role_arn = aws_iam_role.ecs_task_execution.arn
+  task_role_arn      = aws_iam_role.ecs_task_execution.arn
+
+  container_definitions = jsonencode([{
+    name  = var.name
+    image = var.image
+
+    essential = true
+
+    portMappings = [{
+      protocol      = "tcp"
+      containerPort = 4000
+      hostPort      = 4000
+    }]
+
+    logConfiguration = {
+      logDriver = "awslogs",
+      options = {
+        awslogs-group         = var.name
+        awslogs-region        = var.region
+        awslogs-stream-prefix = var.name
+      }
+    }
+
+    environment = [
+      {
+        name  = "DATABASE_URL"
+        value = "postgres://${var.database_username}:${var.database_password}@${var.database_host}:${var.database_port}/${var.database_name}"
+      },
+      {
+        name  = "HOST"
+        value = var.aws_alb_dns
+      },
+      {
+        name  = "SECRET_KEY_BASE"
+        value = "odb/2tIZ9+mBFI8rBMK/OWCRjLuDB+PfKtzv6Td73OfyjDPAjWWLdOmhRozk50rV"
+      },
+      {
+        name  = "PORT"
+        value = "4000"
+      }
+    ]
+
+  }])
+}
+
+resource "aws_ecs_service" "main" {
+  name                               = var.name
+  cluster                            = aws_ecs_cluster.main.id
+  task_definition                    = aws_ecs_task_definition.main.arn
+  desired_count                      = 1
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
+  launch_type                        = "FARGATE"
+  scheduling_strategy                = "REPLICA"
+
+  network_configuration {
+    subnets          = var.subnet_ids
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = var.aws_alb_target_group_arn
+    container_name   = var.name
+    container_port   = 4000
+  }
+}

--- a/hcl/centauri_web/modules/ecs/variables.tf
+++ b/hcl/centauri_web/modules/ecs/variables.tf
@@ -13,3 +13,5 @@ variable "database_username" {}
 variable "database_password" {}
 variable "database_host" {}
 variable "database_port" {}
+
+variable "app_secret_key_base" {}

--- a/hcl/centauri_web/modules/ecs/variables.tf
+++ b/hcl/centauri_web/modules/ecs/variables.tf
@@ -1,0 +1,15 @@
+variable "name" {}
+variable "image" {}
+variable "region" {}
+variable "subnet_ids" {}
+
+variable "aws_alb_target_group_arn" {}
+variable "aws_alb_dns" {}
+
+variable "cloudwatch_log_group_arn" {}
+
+variable "database_name" {}
+variable "database_username" {}
+variable "database_password" {}
+variable "database_host" {}
+variable "database_port" {}

--- a/hcl/centauri_web/modules/log/main.tf
+++ b/hcl/centauri_web/modules/log/main.tf
@@ -1,0 +1,4 @@
+resource "aws_cloudwatch_log_group" "app" {
+  name              = var.name
+  retention_in_days = 14
+}

--- a/hcl/centauri_web/modules/log/outputs.tf
+++ b/hcl/centauri_web/modules/log/outputs.tf
@@ -1,0 +1,7 @@
+output "cloudwatch_log_group_arn" {
+  value = aws_cloudwatch_log_group.app.arn
+}
+
+output "cloudwatch_log_group_name" {
+  value = aws_cloudwatch_log_group.app.name
+}

--- a/hcl/centauri_web/modules/log/variables.tf
+++ b/hcl/centauri_web/modules/log/variables.tf
@@ -1,0 +1,1 @@
+variable "name" {}

--- a/hcl/centauri_web/modules/rds/main.tf
+++ b/hcl/centauri_web/modules/rds/main.tf
@@ -1,0 +1,16 @@
+resource "aws_db_instance" "main" {
+  identifier     = var.db_identifier
+  engine         = var.engine
+  engine_version = var.engine_version
+  instance_class = var.instance_type
+
+  allocated_storage     = var.allocated_storage
+  max_allocated_storage = var.max_allocated_storage
+
+  db_name  = var.db_name
+  username = var.username
+  password = var.password
+  port     = var.port
+
+  skip_final_snapshot = true
+}

--- a/hcl/centauri_web/modules/rds/outputs.tf
+++ b/hcl/centauri_web/modules/rds/outputs.tf
@@ -1,0 +1,7 @@
+output "aws_db_instance_host" {
+  value = aws_db_instance.main.address
+}
+
+output "aws_db_instance_port" {
+  value = aws_db_instance.main.port
+}

--- a/hcl/centauri_web/modules/rds/variables.tf
+++ b/hcl/centauri_web/modules/rds/variables.tf
@@ -1,0 +1,28 @@
+variable "instance_type" {
+  default = "db.t3.small"
+}
+
+variable "engine" {
+  default = "postgres"
+}
+
+variable "engine_version" {
+  default = "14.2"
+}
+
+variable "allocated_storage" {
+  default = 5
+}
+
+variable "max_allocated_storage" {
+  default = 10
+}
+
+variable "port" {
+  default = "5432"
+}
+
+variable "db_identifier" {}
+variable "username" {}
+variable "password" {}
+variable "db_name" {}

--- a/hcl/centauri_web/outputs.tf
+++ b/hcl/centauri_web/outputs.tf
@@ -1,0 +1,3 @@
+output "alb_dns" {
+  value = module.alb.alb_dns
+}

--- a/hcl/centauri_web/variables.tf
+++ b/hcl/centauri_web/variables.tf
@@ -12,3 +12,4 @@ variable "db_password" {}
 
 # ECS
 variable "docker_image" {}
+variable "app_secret_key_base" {}

--- a/hcl/centauri_web/variables.tf
+++ b/hcl/centauri_web/variables.tf
@@ -1,0 +1,14 @@
+variable "name" {}
+variable "region" {}
+variable "vpc_id" {}
+variable "subnet_ids" {
+  type = list(string)
+}
+
+# RDS
+variable "db_name" {}
+variable "db_username" {}
+variable "db_password" {}
+
+# ECS
+variable "docker_image" {}


### PR DESCRIPTION
Close https://github.com/nimblehq/terraform-cloud-development-kit/issues/2

## What happened 👀

Deploy the Centauri Web app with HCL
 
## Insight 📝

1/ Created an ECR shared module so the other teammate can use that ECR and Docker image tag, no need to build any new Docker image tag.

![image](https://user-images.githubusercontent.com/11751745/158162442-99171cc8-a237-458d-abe6-1243f00b7cf4.png)

2/ A typical infrastructure for the Phoenix application

![image](https://user-images.githubusercontent.com/11751745/158162553-fabfcb87-11a3-4165-858f-04cd47f50f05.png)


3/ For demo CDK purposes, everything is in the public VPC network.

4/ State and Environment variables are stored on Terraform cloud.
 
## Proof Of Work 📹

![image](https://user-images.githubusercontent.com/11751745/158162364-5ae21ec7-8684-4ee2-8ac8-5163abf9e1d5.png)

